### PR TITLE
Formats main.js and adds new popup behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ Don't forget to check social media for hashtag **#HackCT2023** and tag your own 
 2. Download Jupyter Notebook and Live Preview (Microsoft version) extensions
 3. Click "Go live" in VS Code to host a local live server
 
+---
+
+Alternatively
+
+1. Clone the repo
+2. Install node.js
+3. Run npx serve
+
 # Data sources
 
 ## UConn Crash Repository:

--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js" integrity="sha512-bLT0Qm9VnAYZDflyKcBaQ2gg0hSYNQrJ8RilYldYQ1FxQYoCLtUjuuRuZo+fjqhx/qtq/1itJ0C2ejDxltZVFg==" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/ion-rangeslider/2.3.1/js/ion.rangeSlider.min.js" integrity="sha512-kZsqvmw94Y8hyhwtWZJvDtobwQ9pLhF1DuIvcqSuracbRn6WJs1Ih+04fpH/8d1CFKysp7XA1tR0Aa2jKLTQUg==" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/leaflet.sync@0.2.4/L.Map.Sync.min.js"></script>
+  <script src=" https://cdn.jsdelivr.net/npm/@turf/turf@6.5.0/turf.min.js "></script>
   <script src="./main.js"></script>
 
 </body>

--- a/main.js
+++ b/main.js
@@ -9,12 +9,12 @@ let map = L.map('map', {
     scrollWheelZoom: 'center',
     attributionControl: false,
     preferCanvas: true
-    })
+})
 
 
 let stringobject = "string"
 
-L.control.zoom({position: 'topright'}).addTo(map)
+L.control.zoom({ position: 'topright' }).addTo(map)
 
 // Add base layer and attach it to map
 let CartoDB_VoyagerLabelsUnder = L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager_labels_under/{z}/{x}/{y}{r}.png', {
@@ -25,10 +25,10 @@ let CartoDB_VoyagerLabelsUnder = L.tileLayer('https://{s}.basemaps.cartocdn.com/
 
 // Add cycle route layer, leave unattached
 let WaymarkedTrails_cycling = L.tileLayer('https://tile.waymarkedtrails.org/cycling/{z}/{x}/{y}.png', {
-        attribution: 'Map data: &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors | Map style: &copy; <a href="https://waymarkedtrails.org">waymarkedtrails.org</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)'
+    attribution: 'Map data: &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors | Map style: &copy; <a href="https://waymarkedtrails.org">waymarkedtrails.org</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)'
 })
 
-$('#bike-lane-show').change(function() { // if the bike-lane-show checkbox is checked (event change)
+$('#bike-lane-show').change(function () { // if the bike-lane-show checkbox is checked (event change)
     if ($(this).prop('checked')) {
         WaymarkedTrails_cycling.addTo(map);
     } else {
@@ -44,15 +44,15 @@ function tsToDate(ts) {
     let d = new Date(ts);
 
     return d.toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'short',
-    day: '2-digit',
+        year: 'numeric',
+        month: 'short',
+        day: '2-digit',
     });
 }
 
 // Set initial dates
-let initFrom = dateToTS( new Date(2015, 0, 1) );
-let initTo = dateToTS( new Date(2023, 7, 23) );
+let initFrom = dateToTS(new Date(2015, 0, 1));
+let initTo = dateToTS(new Date(2023, 7, 23));
 
 // Parse CSV file
 Papa.parse('./data/crashes.csv', {
@@ -61,17 +61,20 @@ Papa.parse('./data/crashes.csv', {
     dynamicTyping: true,
 
     // Main function
-    complete: function(result) {
+    complete: function (result) {
 
         let data = result.data;
 
         let heat = L.heatLayer(
             [],
-            { radius: 5,
-            blur: 3,
-            maxZoom: 17,
-            gradient: {0.4: 'blue', 0.6: 'lime',
-            0.7: 'yellow', 0.8: 'red', 1: 'black'}
+            {
+                radius: 5,
+                blur: 3,
+                maxZoom: 17,
+                gradient: {
+                    0.4: 'blue', 0.6: 'lime',
+                    0.7: 'yellow', 0.8: 'red', 1: 'black'
+                }
             }
         ).addTo(map);
 
@@ -79,45 +82,45 @@ Papa.parse('./data/crashes.csv', {
 
         let tsCoef = 100000.0 // original timestamp needs to be multiplied by this to work in JS
 
-        let updateStatsText = function(
-          formattedFrom,
-          formattedTo,
-          crashesTotal,
-          crashesPed,
-          crashesCyc,
-          crashesHitAndRun,
-          crashesFatal,
-          filtered
+        let updateStatsText = function (
+            formattedFrom,
+            formattedTo,
+            crashesTotal,
+            crashesPed,
+            crashesCyc,
+            crashesHitAndRun,
+            crashesFatal,
+            filtered
         ) {
 
-          let text = formattedFrom === formattedTo
-              ? ('On '+ formattedFrom) : ('From <span class="fw4">'
-              + formattedFrom + ' </span> to  <span class="fw4">'
-              + formattedTo + "</span>")
+            let text = formattedFrom === formattedTo
+                ? ('On ' + formattedFrom) : ('From <span class="fw4">'
+                    + formattedFrom + ' </span> to  <span class="fw4">'
+                    + formattedTo + "</span>")
 
-          text += ', there ' + (crashesTotal === 1 ? 'was ' : 'were  <span class="orange fw5">') + (crashesTotal === 0 ? 'no' : crashesTotal.toLocaleString())
-          text += ' dangerous motor vehicle crash' + (crashesTotal === 1 ? '' : 'es') + '</span> in <b>Northeastern Connecticut</b>.'
+            text += ', there ' + (crashesTotal === 1 ? 'was ' : 'were  <span class="orange fw5">') + (crashesTotal === 0 ? 'no' : crashesTotal.toLocaleString())
+            text += ' dangerous motor vehicle crash' + (crashesTotal === 1 ? '' : 'es') + '</span> in <b>Northeastern Connecticut</b>.'
 
-          if (crashesTotal > 1) {
-              text += ' Of those, <span class="dark-pink fw5">' + (crashesPed > 0 ? crashesPed.toLocaleString() : ' none');
-              text += ' involved a pedestrian</span>, and <span class="dark-blue fw5">';
-              text += (crashesCyc > 0 ? crashesCyc.toLocaleString() : ' none');
-              text += ' involved a cyclist.</span>';
-              text += ' <span class="fw4">' + crashesHitAndRun + ' crashes were hit and runs.</span>';
-              text += ' <span class="dark-red fw6 bb"> ' + crashesFatal + ' crashes were fatal.</span>';
-          }
+            if (crashesTotal > 1) {
+                text += ' Of those, <span class="dark-pink fw5">' + (crashesPed > 0 ? crashesPed.toLocaleString() : ' none');
+                text += ' involved a pedestrian</span>, and <span class="dark-blue fw5">';
+                text += (crashesCyc > 0 ? crashesCyc.toLocaleString() : ' none');
+                text += ' involved a cyclist.</span>';
+                text += ' <span class="fw4">' + crashesHitAndRun + ' crashes were hit and runs.</span>';
+                text += ' <span class="dark-red fw6 bb"> ' + crashesFatal + ' crashes were fatal.</span>';
+            }
 
-          text += '<span class="i dark-green fw5' + (filtered ? '' : 'red') + '"><br><br>'
-              + (filtered ? filtered.toLocaleString() : 'No ') + ' crash'
-              + (filtered === 1 ? '' : 'es') + ' satisf' + (filtered === 1 ? 'ies' : 'y')
-              + ' your filtering criteria.</span>'
+            text += '<span class="i dark-green fw5' + (filtered ? '' : 'red') + '"><br><br>'
+                + (filtered ? filtered.toLocaleString() : 'No ') + ' crash'
+                + (filtered === 1 ? '' : 'es') + ' satisf' + (filtered === 1 ? 'ies' : 'y')
+                + ' your filtering criteria.</span>'
 
-          $('#statsText').html(text) // set the statsText div to the text variable
+            $('#statsText').html(text) // set the statsText div to the text variable
 
         }
 
         // Given `from` and `to` timestamps, updates the heatmap layer.
-        function updateHeatLayer (from, to) {
+        function updateHeatLayer(from, to) {
 
             from = dateToTS(new Date(from * 1).setHours(0, 0, 0, 0)) / tsCoef;
             to = dateToTS(new Date(to * 1).setHours(23, 59, 59, 0)) / tsCoef;
@@ -130,41 +133,41 @@ Papa.parse('./data/crashes.csv', {
 
             // Filter crashes based on checkboxes
             function filterCrashes() {
-              return crashes.filter(function(point) {
-                return (( $('#local').prop('checked') ? point.r !== 1 : false)
-                || ( $('#highways').prop('checked') ? point.r === 1 : false))
+                return crashes.filter(function (point) {
+                    return (($('#local').prop('checked') ? point.r !== 1 : false)
+                        || ($('#highways').prop('checked') ? point.r === 1 : false))
 
-                && (( $('#vehiclesOnly').prop('checked') ? (point.c === 0 && point.p === 0) : false)
-                || ( $('#cyclists').prop('checked') ? point.c === 1 : false)
-                || ( $('#pedestrians').prop('checked') ? point.p === 1 : false))
+                        && (($('#vehiclesOnly').prop('checked') ? (point.c === 0 && point.p === 0) : false)
+                            || ($('#cyclists').prop('checked') ? point.c === 1 : false)
+                            || ($('#pedestrians').prop('checked') ? point.p === 1 : false))
 
-                && (( $('#injury').prop('checked') ? point.s === 'A' : false)
-                || ( $('#fatal').prop('checked') ? point.s === 'K' : true))
+                        && (($('#injury').prop('checked') ? point.s === 'A' : false)
+                            || ($('#fatal').prop('checked') ? point.s === 'K' : true))
 
-                && (( $('#bikelane').prop('checked') ? point.blp === 'True' : true)
-                || ( !$('#bikelane').prop('checked') ? point.blp !== 'True' : false))
+                        && (($('#bikelane').prop('checked') ? point.blp === 'True' : true)
+                            || (!$('#bikelane').prop('checked') ? point.blp !== 'True' : false))
 
-                && (( $('#crashesHitAndRun').prop('checked') ? point.hr === 'True' : true)
-                || ( !$('#crashesHitAndRun').prop('checked') ? point.hr !== 'True' : false))
+                        && (($('#crashesHitAndRun').prop('checked') ? point.hr === 'True' : true)
+                            || (!$('#crashesHitAndRun').prop('checked') ? point.hr !== 'True' : false))
 
-                // filter point 'tn' for town name, or show all towns if empty string
-                && (( $('#town-name').val() === "")
-                || ( $('#town-name').val() === point.tn) ? true : false)
-            });
-          }
+                        // filter point 'tn' for town name, or show all towns if empty string
+                        && (($('#town-name').val() === "")
+                            || ($('#town-name').val() === point.tn) ? true : false)
+                });
+            }
 
-          let crashesFiltered = filterCrashes();
+            let crashesFiltered = filterCrashes();
             console.log("Crashes filtered = ", crashesFiltered);
 
             updateStatsText(
-              tsToDate(from * 100000),  // Date from
-              tsToDate(to * 100000),  // Date to
-              crashes.length, // Total crashes
-              crashes.filter(function(p) {return p.p === 1}).length,  // Ped crashes
-              crashes.filter(function(p) {return p.c === 1}).length,  // Cyc crashes
-              crashes.filter(function(p) {return p.v === 'True'}).length, // Hit and run status
-              crashes.filter(function(p) {return p.s === 'K'}).length, // Fatal crashes
-              crashesFiltered.length
+                tsToDate(from * 100000),  // Date from
+                tsToDate(to * 100000),  // Date to
+                crashes.length, // Total crashes
+                crashes.filter(function (p) { return p.p === 1 }).length,  // Ped crashes
+                crashes.filter(function (p) { return p.c === 1 }).length,  // Cyc crashes
+                crashes.filter(function (p) { return p.v === 'True' }).length, // Hit and run status
+                crashes.filter(function (p) { return p.s === 'K' }).length, // Fatal crashes
+                crashesFiltered.length
             )
 
             // Despite zoom, clear individual points
@@ -174,40 +177,40 @@ Papa.parse('./data/crashes.csv', {
             let intensity = 20;
 
             // Main heatmap
-            document.addEventListener('DOMContentLoaded', function() {
+            document.addEventListener('DOMContentLoaded', function () {
                 // setLatLngs is a Leaflet function that accepts the filtered crashes and sets the heatmap layer to those crashes
                 heat.setLatLngs(
-                    crashesFiltered.map(function(point) { // crashesFiltered is the array of crashes that satisfy the filter criteria
-                    return [point.x, point.y, intensity]; // x and y are the lat and long of the crash, intensity is the intensity of the heatmap
+                    crashesFiltered.map(function (point) { // crashesFiltered is the array of crashes that satisfy the filter criteria
+                        return [point.x, point.y, intensity]; // x and y are the lat and long of the crash, intensity is the intensity of the heatmap
 
-                })
-            )
+                    })
+                )
             });
 
 
             // If zoomed in all the way, show points instead of a heatmap
-            if ( map.getZoom() >= 12 ) {
+            if (map.getZoom() >= 12) {
 
                 heat.redraw();
                 let intensity = 1; // quickly adjusts intensity of heatmap
 
-                crashesFiltered.map(function(crash) { // crash function declared here
+                crashesFiltered.map(function (crash) { // crash function declared here
 
-                let diagramUrl = 'https://www.ctcrash.uconn.edu/MMUCCDiagram?id=' + crash.id + '&asImage=true'
+                    let diagramUrl = 'https://www.ctcrash.uconn.edu/MMUCCDiagram?id=' + crash.id + '&asImage=true'
 
-                // L.circleMarker is a Leaflet function that creates a circle marker at the lat and long of the crash
-                let circle = L.circleMarker([crash.x, crash.y], {
-                    radius: 5,
-                    color: '#000000',
-                    fillColor: '#FFFFFF',
-                    fillOpacity: 1,
-                    opacity: 1,
-                    weight: 2,
+                    // L.circleMarker is a Leaflet function that creates a circle marker at the lat and long of the crash
+                    let circle = L.circleMarker([crash.x, crash.y], {
+                        radius: 5,
+                        color: '#000000',
+                        fillColor: '#FFFFFF',
+                        fillOpacity: 1,
+                        opacity: 1,
+                        weight: 2,
                     }).bindPopup(
                         '<span class="avenir fw5"><p>Crash ID: <b>' + crash.id + '</b></p><p>'
                         + tsToDate(crash.d * tsCoef) + ' at ' + crash.t + '</p>'
                         + '<p>Severity: ' + (crash.s === 'K' ? 'Fatal crash' : crash.s === 'A' ? 'Suspected Serious Injury' : 'Property damage only'
-                        + '<br><p>Trafficway Ownership: ' + crash.s ==='' ? 'Public road' : 'Other')
+                            + '<br><p>Trafficway Ownership: ' + crash.s === '' ? 'Public road' : 'Other')
                         + '<br><p>Motor vehicle was driving on: ' + crash.o + (crash.h === null ? '' : ' and the nearest cross-street is ' + crash.h + '</p>')
                         + '<p>There was ' + (crash.f === 'True' ? 'a bike lane ' : 'no bike lane ') + 'present.</p>'
                         + '<a href="' + diagramUrl + '" target="_blank"><img src="' + diagramUrl + '" style="display:none" alt="Crash diagram" />Show crash diagram.</a>'
@@ -215,47 +218,49 @@ Papa.parse('./data/crashes.csv', {
                         { minWidth: 200 }
                     )
 
-                // Unused function, but could be used to show crash diagram
-                function showDiagram() {
-                    var diagramElement = document.getElementById("diagram");
-                    diagramElement.style.display = "block"
-                }
+                    // Unused function, but could be used to show crash diagram
+                    function showDiagram() {
+                        var diagramElement = document.getElementById("diagram");
+                        diagramElement.style.display = "block"
+                    }
 
-                circle.on('popupopen', function () {
-                    filters.style.display = "none";
-                    map.setLatLng(map.getCenter() + [0, 0.0001]);
-                    console.log(map.getCenter())
-                });
+                    circle.on('popupopen', function () {
+                        filters.style.display = "none";
+                        map.setLatLng(map.getCenter() + [0, 0.0001]);
+                        console.log(map.getCenter())
+                    });
 
-                circle.on('popupclose', function () {
-                    filters.style.display = "block";
-                });
+                    circle.on('popupclose', function () {
+                        filters.style.display = "block";
+                    });
 
-                individualPoints.addLayer(circle); // add the circle to the layergroup
+                    individualPoints.addLayer(circle); // add the circle to the layergroup
                 })
 
                 // If zoomed in all the way, show points instead of a heatmap
                 // Adjust heatmap as zoom changes
-                if ( map.getZoom() >= 17 ) {
+                if (map.getZoom() >= 17) {
                     intensity = 1;
                     heat.setOptions({
-                    maxZoom: 17,
+                        maxZoom: 17,
                     })
 
-                    if ( map.getZoom() >= 18) {
+                    if (map.getZoom() >= 18) {
                         intensity = 0;
                     }
                 } else {
                     intensity = 4;
-                    heat.setOptions({maxZoom: 17,})
+                    heat.setOptions({ maxZoom: 17, })
                 }
 
                 // Update the heatlayer
-                heat.setLatLngs(crashesFiltered.map(function(point) {
-                        return [point.x, point.y, intensity];}))
+                heat.setLatLngs(crashesFiltered.map(function (point) {
+                    return [point.x, point.y, intensity];
+                }))
             } else {
-                heat.setLatLngs(crashesFiltered.map(function(point) {
-                        return [point.x, point.y, intensity];}))
+                heat.setLatLngs(crashesFiltered.map(function (point) {
+                    return [point.x, point.y, intensity];
+                }))
             }
 
         } // End of updateHeatLayer function
@@ -269,8 +274,8 @@ Papa.parse('./data/crashes.csv', {
             to: initTo,
             prettify: tsToDate,
             skin: "big",
-            onChange: function(sliderData) {
-              updateHeatLayer(sliderData.from, sliderData.to);
+            onChange: function (sliderData) {
+                updateHeatLayer(sliderData.from, sliderData.to);
             }
         });
 
@@ -290,12 +295,12 @@ Papa.parse('./data/crashes.csv', {
             )
         })
 
-      // Set default properties
-      $('#filters #pedestrians').prop('checked', 'checked');
-      $('#filters #cyclists').prop('checked', 'checked');
-      $('#filters #fatal').prop('unchecked', 'unchecked');
-      $('#filters #local').prop('checked', 'checked');
-      updateHeatLayer( initFrom, initTo );
+        // Set default properties
+        $('#filters #pedestrians').prop('checked', 'checked');
+        $('#filters #cyclists').prop('checked', 'checked');
+        $('#filters #fatal').prop('unchecked', 'unchecked');
+        $('#filters #local').prop('checked', 'checked');
+        updateHeatLayer(initFrom, initTo);
     }
 
 }) // End of Papa parse

--- a/main.js
+++ b/main.js
@@ -208,18 +208,23 @@ Papa.parse('./data/crashes.csv', {
 
             const features = crashesFiltered.map(crash => {
                 const diagramUrl = 'https://www.ctcrash.uconn.edu/MMUCCDiagram?id=' + crash.id + '&asImage=true'
-                const content = '<span class="avenir fw5"><p>Crash ID: <b>' + crash.id + '</b></p><p>'
-                    + tsToDate(crash.d * tsCoef) + ' at ' + crash.t + '</p>'
-                    + '<p>Severity: ' + (crash.s === 'K' ? 'Fatal crash' : crash.s === 'A' ? 'Suspected Serious Injury' : 'Property damage only'
-                        + '<br><p>Trafficway Ownership: ' + crash.s === '' ? 'Public road' : 'Other')
-                    + '<br><p>Motor vehicle was driving on: ' + crash.o + (crash.h === null ? '' : ' and the nearest cross-street is ' + crash.h + '</p>')
-                    + '<p>There was ' + (crash.f === 'True' ? 'a bike lane ' : 'no bike lane ') + 'present.</p>'
-                    + '<a href="' + diagramUrl + '" target="_blank"><img src="' + diagramUrl + '" style="display:none" alt="Crash diagram" />Show crash diagram.</a>'
-                    + '</span><br>'
-
+                const content = `
+                    <span class="avenir fw5">
+                        <p>Crash ID: <b>${crash.id}</b></p>
+                        <p>${tsToDate(crash.d * tsCoef)} at ${crash.t}</p>
+                        <p>Severity: ${(crash.s === 'K' ? 
+                                            'Fatal crash' : 
+                                            crash.s === 'A' ? 
+                                                'Suspected Serious Injury' :
+                                                'Property damage only' + '<br><p>Trafficway Ownership: ' + crash.s === '' ? 'Public road' : 'Other')}</p>
+                        <p>There was ${crash.f === 'True' ? 'a bike lane' : 'no bike lane'} present.</p>
+                        <a href="${diagramUrl}" target="_blank"><img src="${diagramUrl}" style="display:none" alt="Crash diagram" />Show crash diagram.</a>
+                    </span>
+                    <br>
+                `
                 return {
                     "type": "Feature",
-                    "properties": { diagramUrl, content },
+                    "properties": { ...crash, diagramUrl, content },
                     "geometry": {
                         "type": "Point",
                         "coordinates": [crash.y, crash.x] // seems like x and y are flipped?

--- a/style.css
+++ b/style.css
@@ -12,3 +12,8 @@ label.button p {
     margin-top:0;
     margin-bottom:0;
 }
+
+.leaflet-popup-content{
+    max-height: 60vh;
+    overflow-y: auto;
+}


### PR DESCRIPTION
- When data is filtered the map will pan to the extent of the data
- Popups are enabled at all zoom levels and reworked to show the count at that location based on threshold
- At lower zoom levels, locations more than one crash will show a count. At higher zoom levels it will show all the details of the crashes. (this can be useful to general summaries of that location or street)

A single point will always show details
![A single point will always show details](https://github.com/Transportation-Hackathon-2023/transit-map/assets/9166469/1213bab6-78a3-45f4-9eb6-0b94d1e5de11)

A location with two crashes at zoom level 12 (heatmap), only shows the count
![A location with two crashes at zoom level 12, only shows the count](https://github.com/Transportation-Hackathon-2023/transit-map/assets/9166469/c8075494-11b6-4fd7-a350-d2b52c6bbf3f)

A location with two crashes at zoom level 15, shows all the content for every crash
![A location with two crashes at zoom level 15, shows all the content for every crash](https://github.com/Transportation-Hackathon-2023/transit-map/assets/9166469/59b50375-bc53-4221-be71-3ac9c5a716b3)

